### PR TITLE
Fix: CSS 변수를 사용하여 모달 다크 모드 수정

### DIFF
--- a/src/components/shared/Header.jsx
+++ b/src/components/shared/Header.jsx
@@ -187,21 +187,29 @@ export default function Header() {
       {/* Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-xl shadow-2xl p-6 w-full max-w-md mx-4 relative">
+          <div
+            className="rounded-xl shadow-2xl p-6 w-full max-w-md mx-4 relative"
+            style={{
+              backgroundColor: 'var(--background)',
+              border: '1px solid var(--foreground)',
+              color: 'var(--foreground)'
+            }}
+          >
             <div className="flex items-center justify-between mb-6">
-              <h3 className="text-xl font-semibold dark:text-gray-100">새 폴더 만들기</h3>
+              <h3 className="text-xl font-semibold">새 폴더 만들기</h3>
               <button
                 onClick={() => setShowModal(false)}
-                className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-full transition-colors"
+                className="p-1 rounded-full transition-colors"
+                style={{ color: 'var(--foreground)' }}
               >
-                <svg className="w-6 h-6 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
             </div>
             
             <div className="mb-6">
-              <label className="block text-sm font-medium mb-2 dark:text-gray-300">
+              <label className="block text-sm font-medium mb-2">
                 폴더 이름
               </label>
               <input
@@ -210,7 +218,12 @@ export default function Header() {
                 onChange={(e) => setFolderName(e.target.value)}
                 onKeyPress={handleKeyPress}
                 placeholder="폴더 이름을 입력하세요"
-                className="w-full px-4 py-3 bg-white dark:bg-gray-700 text-black dark:text-white border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:border-blue-500 transition-all outline-none placeholder-gray-400 dark:placeholder-gray-400"
+                className="w-full px-4 py-3 rounded-lg focus:ring-2 focus:ring-[var(--color-accent)] transition-all outline-none"
+                style={{
+                  backgroundColor: 'var(--background)',
+                  color: 'var(--foreground)',
+                  border: '1px solid var(--foreground)'
+                }}
                 disabled={loading}
                 autoFocus
               />
@@ -219,14 +232,14 @@ export default function Header() {
             <div className="flex flex-col sm:flex-row gap-3 sm:justify-end">
               <button 
                 onClick={() => setShowModal(false)} 
-                className="px-6 py-3 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-all order-2 sm:order-1"
+                className="custom-btn px-6 py-3 text-sm font-medium rounded-lg transition-all order-2 sm:order-1"
                 disabled={loading}
               >
                 취소
               </button>
               <button 
                 onClick={createFolder} 
-                className="px-6 py-3 text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed order-1 sm:order-2"
+                className="custom-btn-primary px-6 py-3 text-sm font-medium rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed order-1 sm:order-2"
                 disabled={loading || !folderName.trim()}
               >
                 {loading ? '생성 중...' : '만들기'}


### PR DESCRIPTION
- 기존 `dark:` 접두사 방식이 아닌, 프로젝트의 CSS 변수를 사용하여 모달창의 다크 모드 스타일을 올바르게 수정했습니다.
- 시스템의 라이트/다크 모드 설정에 따라 모달의 배경, 텍스트, 입력 필드, 버튼 색상이 올바르게 변경됩니다.