### PR TITLE
Fix: 갤러리 페이지 정렬 로직 버그 수정

### DIFF
--- a/src/pages/gallery/index.jsx
+++ b/src/pages/gallery/index.jsx
@@ -23,7 +23,9 @@ export default function GalleryPage() {
     try {
       setLoading(true)
 
-      const [sortKey, sortOrder] = sort.split('_')
+      const lastUnderscoreIndex = sort.lastIndexOf('_');
+      const sortKey = sort.substring(0, lastUnderscoreIndex);
+      const sortOrder = sort.substring(lastUnderscoreIndex + 1);
       const isAscending = sortOrder === 'asc'
 
       const { data: photosData, error } = await supabase


### PR DESCRIPTION
- `created_at`과 같이 `_`가 포함된 컬럼 이름을 정렬할 때, 정렬 키를 잘못 파싱하여 발생하던 데이터베이스 오류를 수정했습니다.