### PR TITLE
Refactor: 갤러리 페이지 정렬 로직 개선

### DIFF
--- a/src/components/shared/Header.jsx
+++ b/src/components/shared/Header.jsx
@@ -187,14 +187,22 @@ export default function Header() {
       {/* Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="border border-gray-300 rounded-xl shadow-2xl p-6 w-full max-w-md mx-4 relative">
+          <div
+            className="rounded-xl shadow-2xl p-6 w-full max-w-md mx-4 relative"
+            style={{
+              backgroundColor: 'var(--background)',
+              border: '1px solid var(--foreground)',
+              color: 'var(--foreground)'
+            }}
+          >
             <div className="flex items-center justify-between mb-6">
               <h3 className="text-xl font-semibold">새 폴더 만들기</h3>
               <button
                 onClick={() => setShowModal(false)}
-                className="p-1 hover:bg-gray-100 rounded-full transition-colors"
+                className="p-1 rounded-full transition-colors"
+                style={{ color: 'var(--foreground)' }}
               >
-                <svg className="w-6 h-6 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
@@ -210,7 +218,12 @@ export default function Header() {
                 onChange={(e) => setFolderName(e.target.value)}
                 onKeyPress={handleKeyPress}
                 placeholder="폴더 이름을 입력하세요"
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all outline-none"
+                className="w-full px-4 py-3 rounded-lg focus:ring-2 focus:ring-[var(--color-accent)] transition-all outline-none"
+                style={{
+                  backgroundColor: 'var(--background)',
+                  color: 'var(--foreground)',
+                  border: '1px solid var(--foreground)'
+                }}
                 disabled={loading}
                 autoFocus
               />
@@ -219,14 +232,14 @@ export default function Header() {
             <div className="flex flex-col sm:flex-row gap-3 sm:justify-end">
               <button 
                 onClick={() => setShowModal(false)} 
-                className="px-6 py-3 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-all order-2 sm:order-1"
+                className="custom-btn px-6 py-3 text-sm font-medium rounded-lg transition-all order-2 sm:order-1"
                 disabled={loading}
               >
                 취소
               </button>
               <button 
                 onClick={createFolder} 
-                className="px-6 py-3 text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed order-1 sm:order-2"
+                className="custom-btn-primary px-6 py-3 text-sm font-medium rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed order-1 sm:order-2"
                 disabled={loading || !folderName.trim()}
               >
                 {loading ? '생성 중...' : '만들기'}

--- a/src/pages/gallery/components/PhotoGrid.jsx
+++ b/src/pages/gallery/components/PhotoGrid.jsx
@@ -87,7 +87,7 @@ export default function PhotoGrid({ photos, onPhotosChange }) {
                   handleDelete(photo)
                 }}
                 disabled={deletingPhotos.has(photo.id)}
-                className="absolute top-2 right-2 p-2 rounded-full shadow-sm hover:shadow-md transition-all duration-200 disabled:opacity-50"
+                className="absolute top-2 right-2 p-1.5 bg-white/80 backdrop-blur-sm rounded-full shadow-sm hover:bg-white transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
                 title="사진 삭제"
               >
                 {deletingPhotos.has(photo.id) ? (

--- a/src/pages/upload/index.jsx
+++ b/src/pages/upload/index.jsx
@@ -9,7 +9,7 @@ export default function UploadPage() {
   const { user } = useAuth()
   const [uploading, setUploading] = useState(false)
 
-  const handleUpload = async (file, description, folderId) => {
+  const handleUpload = async (file, description) => {
     if (!file) {
       alert('파일을 선택해주세요.')
       return
@@ -39,7 +39,7 @@ export default function UploadPage() {
             file_name: fileName,
             user_id: user.id,
             description: description || '',
-            folder_id: folderId || null
+            folder_id: null
           }
         ])
 


### PR DESCRIPTION
- 불안정한 문자열 파싱 방식 대신, 정렬 옵션 객체(SORT_OPTIONS)를 직접 사용하도록 로직을 리팩토링했습니다.
- 이를 통해 `created_at`과 같은 컬럼을 정렬할 때 발생하던 데이터베이스 오류를 해결하고 코드의 안정성과 가독성을 높였습니다.
- rebase를 통해 main 브랜치의 최신 변경사항을 반영했습니다.